### PR TITLE
Standardisere NAIS-env elementer og mer clientId

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/konfig/Application.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/Application.java
@@ -1,0 +1,30 @@
+package no.nav.foreldrepenger.konfig;
+
+import static java.lang.System.getenv;
+
+public class Application {
+
+    private final String name;
+
+    private Application(String name) {
+        this.name = name;
+    }
+
+    public static Application of(String name) {
+        return new Application(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Application current() {
+        return Application.of(getenv(NaisProperty.APPLICATION.propertyName()));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[application=" + name + "]";
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/konfig/ApplicationPropertiesKonfigProvider.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/ApplicationPropertiesKonfigProvider.java
@@ -65,7 +65,7 @@ public class ApplicationPropertiesKonfigProvider extends PropertiesKonfigVerdiPr
         }
 
         private static String namespaceName() {
-            return getenv(NAIS_NAMESPACE_NAME);
+            return getenv(NaisProperty.NAMESPACE.propertyName());
         }
 
         private static String clusterKonfig() {
@@ -73,15 +73,13 @@ public class ApplicationPropertiesKonfigProvider extends PropertiesKonfigVerdiPr
         }
 
         private static String clusterName() {
-            return Optional.ofNullable(getenv(NAIS_CLUSTER_NAME))
+            return Optional.ofNullable(getenv(NaisProperty.CLUSTER.propertyName()))
                     .orElse(LOCAL);
         }
     }
 
     private static final int PRIORITET = EnvPropertiesKonfigVerdiProvider.PRIORITET + 1;
     private static final String LOCAL = "local";
-    private static final String NAIS_CLUSTER_NAME = "NAIS_CLUSTER_NAME";
-    private static final String NAIS_NAMESPACE_NAME = "NAIS_NAMESPACE";
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplicationPropertiesKonfigProvider.class);
 

--- a/src/main/java/no/nav/foreldrepenger/konfig/ClientId.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/ClientId.java
@@ -1,0 +1,44 @@
+package no.nav.foreldrepenger.konfig;
+
+import static java.lang.System.getenv;
+
+public class ClientId {
+
+    private static final String DELIMIT = ":";
+
+    private final String clientId;
+
+    private ClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public static ClientId of(String clientId) {
+        return new ClientId(clientId);
+    }
+
+    public static ClientId of(Cluster cluster, Namespace namespace, Application application) {
+        return of(cluster.clusterName(), namespace.getName(), application.getName());
+    }
+
+    public static ClientId of(Cluster cluster, Namespace namespace, String application) {
+        return of(cluster.clusterName(), namespace.getName(), application);
+    }
+
+    private static ClientId of(String cluster, String namespace, String application) {
+        return of(cluster + DELIMIT + namespace + DELIMIT + application);
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public static ClientId current() {
+        return ClientId.of(getenv(NaisProperty.CLIENTID.propertyName()));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[clientId=" + clientId + "]";
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/konfig/Cluster.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/Cluster.java
@@ -3,7 +3,7 @@ package no.nav.foreldrepenger.konfig;
 import static java.lang.System.getenv;
 
 import java.util.Arrays;
-import java.util.Optional;
+import java.util.Objects;
 
 public enum Cluster {
     LOCAL("local"),
@@ -15,8 +15,6 @@ public enum Cluster {
 
     private static final String PROD = "prod";
     private static final String DEV = "dev";
-
-    public static final String NAIS_CLUSTER_NAME = "NAIS_CLUSTER_NAME";
 
     private final String name;
 
@@ -45,8 +43,9 @@ public enum Cluster {
     }
 
     public static Cluster current() {
+        var active = getenv(NaisProperty.CLUSTER.propertyName());
         return Arrays.stream(values())
-                .filter(Cluster::isActive)
+                .filter(c -> active != null && Objects.equals(active, c.name))
                 .findFirst()
                 .orElse(LOCAL);
     }
@@ -56,12 +55,6 @@ public enum Cluster {
                 .filter(v -> v.name.equals(name))
                 .findFirst()
                 .orElseThrow();
-    }
-
-    private boolean isActive() {
-        return Optional.ofNullable(getenv(NAIS_CLUSTER_NAME))
-                .filter(name::equals)
-                .isPresent();
     }
 
 }

--- a/src/main/java/no/nav/foreldrepenger/konfig/NaisProperty.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/NaisProperty.java
@@ -1,0 +1,24 @@
+package no.nav.foreldrepenger.konfig;
+
+/**
+ * Standard navn på environment injisert av NAIS
+ * Med vilje ikke public slik at man heller går via Environment
+ */
+enum NaisProperty {
+    CLUSTER("NAIS_CLUSTER_NAME"),
+    NAMESPACE("NAIS_NAMESPACE"),
+    APPLICATION("NAIS_APP_NAME"),
+    CLIENTID("NAIS_CLIENT_ID"), // Format <cluster>:<namespace>:<application>
+    ;
+
+    private final String name;
+
+    NaisProperty(String name) {
+        this.name = name;
+    }
+
+    String propertyName() {
+        return name;
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/konfig/Namespace.java
+++ b/src/main/java/no/nav/foreldrepenger/konfig/Namespace.java
@@ -5,7 +5,6 @@ import static java.lang.System.getenv;
 import java.util.Optional;
 
 public class Namespace {
-    public static final String NAIS_NAMESPACE_NAME = "NAIS_NAMESPACE";
 
     private static final String DEFAULT_NAMESPACE = "teamforeldrepenger";
 
@@ -24,7 +23,7 @@ public class Namespace {
     }
 
     public static Namespace current() {
-        return Namespace.of(Optional.ofNullable(getenv(NAIS_NAMESPACE_NAME))
+        return Namespace.of(Optional.ofNullable(getenv(NaisProperty.NAMESPACE.propertyName()))
                 .orElse(DEFAULT_NAMESPACE));
     }
 


### PR DESCRIPTION
Strammer inn på frie referanser til NAIS_ - environment
Legger inn application +clientId i Environment
Bedre støtte for å bygge scopes (azure+tokenX) i ClientId